### PR TITLE
Upload data.json as an artifact on each build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,13 @@ jobs:
 
       - name: Expose JSON data
         run: cp build/data.json dist/data.json
-
+      
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2.2.2
+        with:
+          # Artifact name
+          name: data.json
+          path: build/data.json
       - name: Add CNAME
         run: echo "pogchamp.today" > dist/CNAME
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,10 @@ jobs:
         run: cp build/data.json dist/data.json
         
       - name: Download old artifact
-        uses: actions/download-artifact@v2
+        uses: dawidd6/action-download-artifact@v2
         with:
+          workflow: build.yml
+          workflow_conclusion: completed
           name: data.json
           path: build/old.json
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,13 +50,32 @@ jobs:
 
       - name: Expose JSON data
         run: cp build/data.json dist/data.json
+        
+      - name: Download old artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: data.json
+          path: build/old.json
+
+      - name: Compare both artifacts
+        run: (diff build/data.json build/old.json &&  echo "NOT OK" | grep "NOT OK") && false # will exit the workflow with an error, stopping next build steps
+      
+      - name: Download combined artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: all.json
+          path: build/all.json
+
+      - name: Combine artifacts
+        run: jq -s . build/all.json build/data.json > build/all.json
       
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2.2.2
         with:
           # Artifact name
-          name: data.json
-          path: build/data.json
+          name: all.json
+          path: build/all.json
+      
       - name: Add CNAME
         run: echo "pogchamp.today" > dist/CNAME
 


### PR DESCRIPTION
This PR uploads the `data.json` file as an artifact on each build. This way, we can track past pogs so we can access them later.

This PR closes #3.